### PR TITLE
Add MarkupContent and TextDocumentSyncOptions, remove unused uses

### DIFF
--- a/src/CompletionItem.php
+++ b/src/CompletionItem.php
@@ -3,8 +3,6 @@ declare(strict_types = 1);
 
 namespace LanguageServerProtocol;
 
-use LanguageServer\Definition;
-
 class CompletionItem
 {
     /**
@@ -40,7 +38,7 @@ class CompletionItem
     public $documentation;
 
     /**
-     * A string that shoud be used when comparing this item
+     * A string that should be used when comparing this item
      * with other items. When `falsy` the label is used.
      *
      * @var string|null

--- a/src/DocumentHighlightKind.php
+++ b/src/DocumentHighlightKind.php
@@ -8,7 +8,7 @@ namespace LanguageServerProtocol;
 abstract class DocumentHighlightKind
 {
     /**
-     * A textual occurrance.
+     * A textual occurrence.
      */
     const TEXT = 1;
 

--- a/src/Hover.php
+++ b/src/Hover.php
@@ -10,7 +10,7 @@ class Hover
     /**
      * The hover's content
      *
-     * @var string|MarkedString|string[]|MarkedString[]
+     * @var string|MarkedString|string[]|MarkedString[]|MarkupContent
      */
     public $contents;
 

--- a/src/Location.php
+++ b/src/Location.php
@@ -2,9 +2,6 @@
 
 namespace LanguageServerProtocol;
 
-use Microsoft\PhpParser;
-use Microsoft\PhpParser\Node;
-
 /**
  * Represents a location inside a resource, such as a line inside a text file.
  */

--- a/src/MarkupContent.php
+++ b/src/MarkupContent.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * A `MarkupContent` literal represents a string value which content is interpreted base on its
+ * kind flag. Currently the protocol supports `plaintext` and `markdown` as markup kinds.
+ *
+ * If the kind is `markdown` then the value can contain fenced code blocks like in GitHub issues.
+ * See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
+ *
+ * Here is an example how such a string can be constructed using JavaScript / TypeScript:
+ * ```ts
+ * let markdown: MarkdownContent = {
+ *  kind: MarkupKind.Markdown,
+ *  value: [
+ *      '# Header',
+ *      'Some text',
+ *      '```typescript',
+ *      'someCode();',
+ *      '```'
+ *  ].join('\n')
+ * };
+ * ```
+ *
+ * *Please Note* that clients might sanitize the return markdown. A client could decide to
+ * remove HTML from the markdown to avoid script execution.
+ */
+class MarkupContent
+{
+    /**
+     * @var string the type of the Markup (from MarkupKind)
+     */
+    public $kind;
+
+    /**
+     * @var string the content itself
+     */
+    public $value;
+
+    /**
+     * @param string $kind the type of the Markup
+     * @param string $value the content itself
+     */
+    public function __construct(string $kind = null, string $value = null)
+    {
+        $this->kind = $kind;
+        $this->value = $value;
+    }
+}

--- a/src/MarkupKind.php
+++ b/src/MarkupKind.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * Describes the content type that a client supports in various
+ * result literals like `Hover`, `ParameterInfo` or `CompletionItem`.
+ *
+ * Please note that `MarkupKinds` must not start with a `$`. This kinds
+ * are reserved for internal usage.
+ */
+abstract class MarkupKind
+{
+	/**
+	 * Plain text is supported as a content format
+	 */
+    const PLAINTEXT = 'plaintext';
+
+	/**
+	 * Markdown is supported as a content format
+	 */
+    const MARKDOWN = 'markdown';
+}

--- a/src/MarkupKind.php
+++ b/src/MarkupKind.php
@@ -11,13 +11,13 @@ namespace LanguageServerProtocol;
  */
 abstract class MarkupKind
 {
-	/**
-	 * Plain text is supported as a content format
-	 */
+    /**
+     * Plain text is supported as a content format
+     */
     const PLAINTEXT = 'plaintext';
 
-	/**
-	 * Markdown is supported as a content format
-	 */
+    /**
+     * Markdown is supported as a content format
+     */
     const MARKDOWN = 'markdown';
 }

--- a/src/Range.php
+++ b/src/Range.php
@@ -2,9 +2,6 @@
 
 namespace LanguageServerProtocol;
 
-use Microsoft\PhpParser;
-use Microsoft\PhpParser\Node;
-
 /**
  * A range in a text document expressed as (zero-based) start and end positions.
  */

--- a/src/SaveOptions.php
+++ b/src/SaveOptions.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * Options controlling what is sent to the server with save notifications.
+ */
+class SaveOptions
+{
+    /**
+     * The client is supposed to include the content on save.
+     * @var bool|null
+     */
+    public $includeText;
+}

--- a/src/ServerCapabilities.php
+++ b/src/ServerCapabilities.php
@@ -7,7 +7,7 @@ class ServerCapabilities
     /**
      * Defines how text documents are synced.
      *
-     * @var int|null
+     * @var TextDocumentSyncOptions|int|null
      */
     public $textDocumentSync;
 

--- a/src/SymbolInformation.php
+++ b/src/SymbolInformation.php
@@ -2,9 +2,6 @@
 
 namespace LanguageServerProtocol;
 
-use Microsoft\PhpParser;
-use Microsoft\PhpParser\Node;
-
 /**
  * Represents information about programming constructs like variables, classes,
  * interfaces etc.

--- a/src/TextDocumentSyncOptions.php
+++ b/src/TextDocumentSyncOptions.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace LanguageServerProtocol;
+
+/**
+ * A detailed structure defining expected notifications from the client of changes to text documents.
+ */
+class TextDocumentSyncOptions
+{
+    /**
+     * Open and close notifications are sent to the server.
+     * @var bool|null
+     */
+    public $openClose;
+
+    /**
+     * Change notifications are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
+     * and TextDocumentSyncKindIncremental.
+     * @var int|null
+     */
+    public $change;
+
+    /**
+     * Will save notifications get sent to the server.
+     * @var bool|null
+     */
+    public $willSave;
+
+    /**
+     * Will save wait until requests get sent to the server.
+     * @var bool|null
+     */
+    public $willSaveWaitUntil;
+
+    /**
+     * Save notifications are sent to the server.
+     * @var SaveOptions|null
+     */
+    public $save;
+}


### PR DESCRIPTION
Fixes #4

Fix typos (detected by codespell, should have already been fixed in specification document)
remove unused use statements (detected by Phan)