### PR TITLE
Consistently start doc comments of properties with `/**`

### DIFF
--- a/src/CompletionOptions.php
+++ b/src/CompletionOptions.php
@@ -7,7 +7,7 @@ namespace LanguageServerProtocol;
  */
 class CompletionOptions
 {
-    /*
+    /**
      * The server provides support to resolve additional information for a completion
      * item.
      *

--- a/src/TextDocumentSyncKind.php
+++ b/src/TextDocumentSyncKind.php
@@ -17,7 +17,7 @@ abstract class TextDocumentSyncKind
      */
     const FULL = 1;
 
-    /*
+    /**
      * Documents are synced by sending the full content on open. After that only
      * incremental updates to the document are sent.
      */


### PR DESCRIPTION
Noticed when looking at CompletionOptions