### PR TITLE
Allow [int, int] tuple for ParameterInformation label

### DIFF
--- a/src/ParameterInformation.php
+++ b/src/ParameterInformation.php
@@ -9,10 +9,16 @@ namespace LanguageServerProtocol;
 class ParameterInformation
 {
     /**
-     * The label of this signature. Will be shown in
-     * the UI.
+     * The label of this parameter information.
      *
-     * @var string
+     * Either a string or an inclusive start and exclusive end offsets within its containing
+     * signature label. (see SignatureInformation.label). The offsets are based on a UTF-16
+     * string representation as `Position` and `Range` does.
+     *
+     * *Note*: a label of type string should be a substring of its containing signature label.
+     * Its intended use case is to highlight the parameter label part in the `SignatureInformation.label`.
+     *
+     * @var string|int[]
      */
     public $label;
 
@@ -27,11 +33,11 @@ class ParameterInformation
     /**
      * Create ParameterInformation
      *
-     * @param string $label         The label of this signature. Will be shown in the UI.
+     * @param string|int[] $label   The label of this parameter information.
      * @param string $documentation The human-readable doc-comment of this signature. Will be shown in the UI but can
      *                              be omitted.
      */
-    public function __construct(string $label, string $documentation = null)
+    public function __construct($label, string $documentation = null)
     {
         $this->label = $label;
         $this->documentation = $documentation;


### PR DESCRIPTION
According to the docs a start/stop position can be provided as the
ParameterInformation label that denotes the position of the parameter in
the SignatureInformation label.