### PR TITLE
feat: Add JSON serialization to omit null values

### DIFF
--- a/src/ClientCapabilities.php
+++ b/src/ClientCapabilities.php
@@ -2,7 +2,7 @@
 
 namespace LanguageServerProtocol;
 
-class ClientCapabilities
+class ClientCapabilities implements \JsonSerializable
 {
     /**
      * The client supports workspace/xfiles requests
@@ -30,5 +30,23 @@ class ClientCapabilities
         $this->xfilesProvider = $xfilesProvider;
         $this->xcontentProvider = $xcontentProvider;
         $this->xcacheProvider = $xcacheProvider;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/CodeLens.php
+++ b/src/CodeLens.php
@@ -9,7 +9,7 @@ namespace LanguageServerProtocol;
  * A code lens is _unresolved_ when no command is associated to it. For performance
  * reasons the creation of a code lens and resolving should be done in two stages.
  */
-class CodeLens
+class CodeLens implements \JsonSerializable
 {
     /**
      * The range in which this code lens is valid. Should only span a single line.
@@ -38,5 +38,23 @@ class CodeLens
         $this->range = $range;
         $this->command = $command;
         $this->data = $data;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/CodeLensOptions.php
+++ b/src/CodeLensOptions.php
@@ -5,7 +5,7 @@ namespace LanguageServerProtocol;
 /**
  * Code Lens options.
  */
-class CodeLensOptions
+class CodeLensOptions implements \JsonSerializable
 {
     /**
      * Code lens has a resolve provider as well.
@@ -17,5 +17,23 @@ class CodeLensOptions
     public function __construct(bool $resolveProvider = null)
     {
         $this->resolveProvider = $resolveProvider;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/Command.php
+++ b/src/Command.php
@@ -6,7 +6,7 @@ namespace LanguageServerProtocol;
  * Represents a reference to a command. Provides a title which will be used to represent a command in the UI and,
  * optionally, an array of arguments which will be passed to the command handler function when invoked.
  */
-class Command
+class Command implements \JsonSerializable
 {
     /**
      * Title of the command, like `save`.
@@ -35,5 +35,23 @@ class Command
         $this->title = $title;
         $this->command = $command;
         $this->arguments = $arguments;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/CompletionContext.php
+++ b/src/CompletionContext.php
@@ -5,7 +5,7 @@ namespace LanguageServerProtocol;
 /**
  * Contains additional information about the context in which a completion request is triggered.
  */
-class CompletionContext
+class CompletionContext implements \JsonSerializable
 {
     /**
      * How the completion was triggered.
@@ -26,5 +26,23 @@ class CompletionContext
     {
         $this->triggerKind = $triggerKind;
         $this->triggerCharacter = $triggerCharacter;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/CompletionItem.php
+++ b/src/CompletionItem.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace LanguageServerProtocol;
 
-class CompletionItem
+class CompletionItem implements \JsonSerializable
 {
     /**
      * The label of this completion item. By default
@@ -145,5 +145,23 @@ class CompletionItem
         $this->command = $command;
         $this->data = $data;
         $this->insertTextFormat = $insertTextFormat;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/CompletionOptions.php
+++ b/src/CompletionOptions.php
@@ -5,7 +5,7 @@ namespace LanguageServerProtocol;
 /**
  * Completion options.
  */
-class CompletionOptions
+class CompletionOptions implements \JsonSerializable
 {
     /**
      * The server provides support to resolve additional information for a completion
@@ -26,5 +26,23 @@ class CompletionOptions
     {
         $this->resolveProvider = $resolveProvider;
         $this->triggerCharacters = $triggerCharacters;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/Diagnostic.php
+++ b/src/Diagnostic.php
@@ -6,7 +6,7 @@ namespace LanguageServerProtocol;
  * Represents a diagnostic, such as a compiler error or warning. Diagnostic objects are only valid in the scope of a
  * resource.
  */
-class Diagnostic
+class Diagnostic implements \JsonSerializable
 {
     /**
      * The range at which the message applies.
@@ -59,5 +59,23 @@ class Diagnostic
         $this->code = $code;
         $this->severity = $severity;
         $this->source = $source;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/DocumentHighlight.php
+++ b/src/DocumentHighlight.php
@@ -7,7 +7,7 @@ namespace LanguageServerProtocol;
  * special attention. Usually a document highlight is visualized by changing
  * the background color of its range.
  */
-class DocumentHighlight
+class DocumentHighlight implements \JsonSerializable
 {
     /**
      * The range this highlight applies to.
@@ -27,5 +27,23 @@ class DocumentHighlight
     {
         $this->range = $range;
         $this->kind = $kind;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/DocumentOnTypeFormattingOptions.php
+++ b/src/DocumentOnTypeFormattingOptions.php
@@ -5,7 +5,7 @@ namespace LanguageServerProtocol;
 /**
  * Format document on type options
  */
-class DocumentOnTypeFormattingOptions
+class DocumentOnTypeFormattingOptions implements \JsonSerializable
 {
     /**
      * A character on which formatting should be triggered, like `}`.
@@ -25,5 +25,23 @@ class DocumentOnTypeFormattingOptions
     {
         $this->firstTriggerCharacter = $firstTriggerCharacter;
         $this->moreTriggerCharacter = $moreTriggerCharacter;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/Hover.php
+++ b/src/Hover.php
@@ -5,7 +5,7 @@ namespace LanguageServerProtocol;
 /**
  * The result of a hover request.
  */
-class Hover
+class Hover implements \JsonSerializable
 {
     /**
      * The hover's content
@@ -29,5 +29,23 @@ class Hover
     {
         $this->contents = $contents;
         $this->range = $range;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/ParameterInformation.php
+++ b/src/ParameterInformation.php
@@ -6,7 +6,7 @@ namespace LanguageServerProtocol;
  * Represents a parameter of a callable-signature. A parameter can
  * have a label and a doc-comment.
  */
-class ParameterInformation
+class ParameterInformation implements \JsonSerializable
 {
     /**
      * The label of this parameter information.
@@ -41,5 +41,23 @@ class ParameterInformation
     {
         $this->label = $label;
         $this->documentation = $documentation;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/SaveOptions.php
+++ b/src/SaveOptions.php
@@ -5,11 +5,29 @@ namespace LanguageServerProtocol;
 /**
  * Options controlling what is sent to the server with save notifications.
  */
-class SaveOptions
+class SaveOptions implements \JsonSerializable
 {
     /**
      * The client is supposed to include the content on save.
      * @var bool|null
      */
     public $includeText;
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
+    }
 }

--- a/src/ServerCapabilities.php
+++ b/src/ServerCapabilities.php
@@ -2,7 +2,7 @@
 
 namespace LanguageServerProtocol;
 
-class ServerCapabilities
+class ServerCapabilities implements \JsonSerializable
 {
     /**
      * Defines how text documents are synced.
@@ -129,4 +129,22 @@ class ServerCapabilities
      * @var bool|null
      */
     public $dependenciesProvider;
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
+    }
 }

--- a/src/SignatureHelp.php
+++ b/src/SignatureHelp.php
@@ -7,7 +7,7 @@ namespace LanguageServerProtocol;
  * callable. There can be multiple signature but only one
  * active and only one active parameter.
  */
-class SignatureHelp
+class SignatureHelp implements \JsonSerializable
 {
     /**
      * One or more signatures.
@@ -42,5 +42,23 @@ class SignatureHelp
         $this->signatures = $signatures;
         $this->activeSignature = $activeSignature;
         $this->activeParameter = $activeParameter;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/SignatureHelpOptions.php
+++ b/src/SignatureHelpOptions.php
@@ -5,7 +5,7 @@ namespace LanguageServerProtocol;
 /**
  * Signature help options.
  */
-class SignatureHelpOptions
+class SignatureHelpOptions implements \JsonSerializable
 {
     /**
      * The characters that trigger signature help automatically.
@@ -17,5 +17,23 @@ class SignatureHelpOptions
     public function __construct(array $triggerCharacters = null)
     {
         $this->triggerCharacters = $triggerCharacters;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/SignatureInformation.php
+++ b/src/SignatureInformation.php
@@ -7,7 +7,7 @@ namespace LanguageServerProtocol;
  * can have a label, like a function-name, a doc-comment, and
  * a set of parameters.
  */
-class SignatureInformation
+class SignatureInformation implements \JsonSerializable
 {
     /**
      * The label of this signature. Will be shown in
@@ -45,5 +45,23 @@ class SignatureInformation
         $this->label = $label;
         $this->parameters = $parameters;
         $this->documentation = $documentation;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/SymbolInformation.php
+++ b/src/SymbolInformation.php
@@ -6,7 +6,7 @@ namespace LanguageServerProtocol;
  * Represents information about programming constructs like variables, classes,
  * interfaces etc.
  */
-class SymbolInformation
+class SymbolInformation implements \JsonSerializable
 {
     /**
      * The name of this symbol.
@@ -48,5 +48,23 @@ class SymbolInformation
         $this->kind = $kind;
         $this->location = $location;
         $this->containerName = $containerName;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/TextDocumentContentChangeEvent.php
+++ b/src/TextDocumentContentChangeEvent.php
@@ -6,7 +6,7 @@ namespace LanguageServerProtocol;
  * An event describing a change to a text document. If range and rangeLength are omitted
  * the new text is considered to be the full content of the document.
  */
-class TextDocumentContentChangeEvent
+class TextDocumentContentChangeEvent implements \JsonSerializable
 {
     /**
      * The range of the document that changed.
@@ -34,5 +34,23 @@ class TextDocumentContentChangeEvent
         $this->range = $range;
         $this->rangeLength = $rangeLength;
         $this->text = $text;
+    }
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/TextDocumentSyncOptions.php
+++ b/src/TextDocumentSyncOptions.php
@@ -6,7 +6,7 @@ namespace LanguageServerProtocol;
 /**
  * A detailed structure defining expected notifications from the client of changes to text documents.
  */
-class TextDocumentSyncOptions
+class TextDocumentSyncOptions implements \JsonSerializable
 {
     /**
      * Open and close notifications are sent to the server.
@@ -38,4 +38,22 @@ class TextDocumentSyncOptions
      * @var SaveOptions|null
      */
     public $save;
+
+    /**
+     * Only serialize properties with valid values.
+     *
+     * @return object
+     */
+    public function jsonSerialize()
+    {
+        $fields = new \stdClass;
+
+        foreach (get_object_vars($this) as $name => $value) {
+            if ($value !== null) {
+                $fields->$name = $value;
+            }
+        }
+
+        return $fields;
+    }
 }


### PR DESCRIPTION
Several classes contain attributes with null values, where the specification requires them to be omitted.

This adds implementations of JsonSerializable to automatically omit these attributes on serialization.

All language servers I could find using this package simply call `json_encode` on the message, so this seems like a sane addition.

Fixes felixfbecker/php-language-server#758