### PR TITLE
fix: support PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - '7.0'
   - '7.3'
   - '7.4'
-  - '8.0'
+  - nightly
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
   - '7.0'
   - '7.3'
+  - '7.4'
+  - '8.0'
 
 env:
   global:

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,9 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": ">=7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.3",
         "phpstan/phpstan": "*",
         "squizlabs/php_codesniffer": "^3.1"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,4 @@
 parameters:
+    reportUnmatchedIgnoredErrors: false
     ignoreErrors:
+        - '#Property .* does not accept#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,2 @@
 parameters:
     ignoreErrors:
-        - '#Property .* does not accept#'

--- a/src/CodeLens.php
+++ b/src/CodeLens.php
@@ -34,8 +34,6 @@ class CodeLens
     public $data;
 
     /**
-     * @param Range|null $range
-     * @param Command|null $command
      * @param mixed $data
      */
     public function __construct(Range $range = null, Command $command = null, $data = null)

--- a/src/CodeLens.php
+++ b/src/CodeLens.php
@@ -33,6 +33,11 @@ class CodeLens
      */
     public $data;
 
+    /**
+     * @param Range|null $range
+     * @param Command|null $command
+     * @param mixed $data
+     */
     public function __construct(Range $range = null, Command $command = null, $data = null)
     {
         $this->range = $range;

--- a/src/Command.php
+++ b/src/Command.php
@@ -11,14 +11,14 @@ class Command
     /**
      * Title of the command, like `save`.
      *
-     * @var string
+     * @var string|null
      */
     public $title;
 
     /**
      * The identifier of the actual command handler.
      *
-     * @var string
+     * @var string|null
      */
     public $command;
 
@@ -30,6 +30,11 @@ class Command
      */
     public $arguments;
 
+    /**
+     * @param string|null $title
+     * @param string|null $command
+     * @param mixed[]|null $arguments
+     */
     public function __construct(string $title = null, string $command = null, array $arguments = null)
     {
         $this->title = $title;

--- a/src/Command.php
+++ b/src/Command.php
@@ -31,8 +31,6 @@ class Command
     public $arguments;
 
     /**
-     * @param string|null $title
-     * @param string|null $command
      * @param mixed[]|null $arguments
      */
     public function __construct(string $title = null, string $command = null, array $arguments = null)

--- a/src/CompletionItemKind.php
+++ b/src/CompletionItemKind.php
@@ -52,8 +52,6 @@ abstract class CompletionItemKind
                 return self::MODULE;
             case SymbolKind::FILE:
                 return self::FILE;
-            case SymbolKind::STRING:
-                return self::TEXT;
             case SymbolKind::NUMBER:
             case SymbolKind::BOOLEAN:
             case SymbolKind::ARRAY:
@@ -65,6 +63,9 @@ abstract class CompletionItemKind
             case SymbolKind::VARIABLE:
             case SymbolKind::CONSTANT:
                 return self::VARIABLE;
+            case SymbolKind::STRING:
+            default:
+                return self::TEXT;
         }
     }
 }

--- a/src/CompletionOptions.php
+++ b/src/CompletionOptions.php
@@ -22,6 +22,10 @@ class CompletionOptions
      */
     public $triggerCharacters;
 
+    /**
+     * @param bool|null $resolveProvider
+     * @param string[]|null $triggerCharacters
+     */
     public function __construct(bool $resolveProvider = null, array $triggerCharacters = null)
     {
         $this->resolveProvider = $resolveProvider;

--- a/src/CompletionOptions.php
+++ b/src/CompletionOptions.php
@@ -23,7 +23,6 @@ class CompletionOptions
     public $triggerCharacters;
 
     /**
-     * @param bool|null $resolveProvider
      * @param string[]|null $triggerCharacters
      */
     public function __construct(bool $resolveProvider = null, array $triggerCharacters = null)

--- a/src/DocumentOnTypeFormattingOptions.php
+++ b/src/DocumentOnTypeFormattingOptions.php
@@ -22,7 +22,6 @@ class DocumentOnTypeFormattingOptions
     public $moreTriggerCharacter;
 
     /**
-     * @param string|null $firstTriggerCharacter
      * @param string[]|null $moreTriggerCharacter
      */
     public function __construct(string $firstTriggerCharacter = null, array $moreTriggerCharacter = null)

--- a/src/DocumentOnTypeFormattingOptions.php
+++ b/src/DocumentOnTypeFormattingOptions.php
@@ -21,6 +21,10 @@ class DocumentOnTypeFormattingOptions
      */
     public $moreTriggerCharacter;
 
+    /**
+     * @param string|null $firstTriggerCharacter
+     * @param string[]|null $moreTriggerCharacter
+     */
     public function __construct(string $firstTriggerCharacter = null, array $moreTriggerCharacter = null)
     {
         $this->firstTriggerCharacter = $firstTriggerCharacter;

--- a/src/SignatureHelpOptions.php
+++ b/src/SignatureHelpOptions.php
@@ -14,6 +14,9 @@ class SignatureHelpOptions
      */
     public $triggerCharacters;
 
+    /**
+     * @param string[]|null $triggerCharacters
+     */
     public function __construct(array $triggerCharacters = null)
     {
         $this->triggerCharacters = $triggerCharacters;


### PR DESCRIPTION
Hey there,

your package is a dependency for many other packages and therefor it would be nice to allow php 8. There is only one change that I would classify as "potentially critical" in order to have a running phpstan analysis: I had to add a default behaviour to the switch case of `LanguageServerProtocol\CompletionItemKind::fromSymbolKind`, which is indeed required, as the return type hint only allows integer values.

Otherwise travis CI runs without problems under php 7.0, 7.3, 7.4 and 8.0-dev.