### PR TITLE
Allow Hover to be created with MarkupContent

### DIFF
--- a/src/Hover.php
+++ b/src/Hover.php
@@ -22,7 +22,7 @@ class Hover
     public $range;
 
     /**
-     * @param string|MarkedString|string[]|MarkedString[] $contents The hover's content
+     * @param string|MarkedString|string[]|MarkedString[]|MarkupContent $contents The hover's content
      * @param Range $range An optional range
      */
     public function __construct($contents = null, $range = null)


### PR DESCRIPTION
It appears this was missed in https://github.com/felixfbecker/php-language-server-protocol/pull/5, which sets the property to allow MarkupContent, but doesn't allow instantiating the object with it.