### PR TITLE
fix: signature help must not send null fields

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 /.gitattributes export-ignore
 /.gitignore export-ignore

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,0 +1,25 @@
+name: 'Semantic Pull Request'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+#  pull_request:
+#    types:
+#      - opened
+#      - edited
+#      - synchronize
+
+jobs:
+  main:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: semantic-pull-request
+        uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: false

--- a/src/ParameterInformation.php
+++ b/src/ParameterInformation.php
@@ -42,7 +42,9 @@ class ParameterInformation implements JsonSerializable
     public function __construct($label, $documentation = null)
     {
         $this->label = $label;
-        if ($this->documentation !== null) $this->documentation = $documentation;
+        if ($this->documentation !== null) {
+            $this->documentation = $documentation;
+        }
     }
 
     /**

--- a/src/ParameterInformation.php
+++ b/src/ParameterInformation.php
@@ -42,9 +42,7 @@ class ParameterInformation implements JsonSerializable
     public function __construct($label, $documentation = null)
     {
         $this->label = $label;
-        if ($this->documentation !== null) {
-            $this->documentation = $documentation;
-        }
+        $this->documentation = $documentation;
     }
 
     /**

--- a/src/ParameterInformation.php
+++ b/src/ParameterInformation.php
@@ -2,11 +2,13 @@
 
 namespace LanguageServerProtocol;
 
+use JsonSerializable;
+
 /**
  * Represents a parameter of a callable-signature. A parameter can
  * have a label and a doc-comment.
  */
-class ParameterInformation
+class ParameterInformation implements JsonSerializable
 {
     /**
      * The label of this parameter information.
@@ -40,6 +42,18 @@ class ParameterInformation
     public function __construct($label, $documentation = null)
     {
         $this->label = $label;
-        $this->documentation = $documentation;
+        if ($this->documentation !== null) $this->documentation = $documentation;
+    }
+
+    /**
+     * This is needed because VSCode Does not like nulls
+     * meaning if a null is sent then this will not compute
+     *
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        return array_filter(get_object_vars($this));
     }
 }

--- a/src/SignatureHelp.php
+++ b/src/SignatureHelp.php
@@ -57,12 +57,8 @@ class SignatureHelp implements JsonSerializable
     public function __construct(array $signatures = null, $activeSignature = null, int $activeParameter = null)
     {
         $this->signatures = $signatures;
-        if ($this->activeSignature !== null) {
-            $this->activeSignature = $activeSignature;
-        }
-        if ($this->activeParameter !== null) {
-            $this->activeParameter = $activeParameter;
-        }
+        $this->activeSignature = $activeSignature;
+        $this->activeParameter = $activeParameter;
     }
 
     /**
@@ -74,6 +70,8 @@ class SignatureHelp implements JsonSerializable
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
-        return array_filter(get_object_vars($this));
+        return array_filter(get_object_vars($this), function ($v) {
+            return $v !== null;
+        });
     }
 }

--- a/src/SignatureHelp.php
+++ b/src/SignatureHelp.php
@@ -2,12 +2,14 @@
 
 namespace LanguageServerProtocol;
 
+use JsonSerializable;
+
 /**
  * Signature help represents the signature of something
  * callable. There can be multiple signature but only one
  * active and only one active parameter.
  */
-class SignatureHelp
+class SignatureHelp implements JsonSerializable
 {
     /**
      * One or more signatures. If no signatures are available the signature help
@@ -55,7 +57,19 @@ class SignatureHelp
     public function __construct(array $signatures = null, $activeSignature = null, int $activeParameter = null)
     {
         $this->signatures = $signatures;
-        $this->activeSignature = $activeSignature;
-        $this->activeParameter = $activeParameter;
+        if ($this->activeSignature !== null) $this->activeSignature = $activeSignature;
+        if ($this->activeParameter !== null) $this->activeParameter = $activeParameter;
+    }
+
+    /**
+     * This is needed because VSCode Does not like nulls
+     * meaning if a null is sent then this will not compute
+     *
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        return array_filter(get_object_vars($this));
     }
 }

--- a/src/SignatureHelp.php
+++ b/src/SignatureHelp.php
@@ -57,8 +57,12 @@ class SignatureHelp implements JsonSerializable
     public function __construct(array $signatures = null, $activeSignature = null, int $activeParameter = null)
     {
         $this->signatures = $signatures;
-        if ($this->activeSignature !== null) $this->activeSignature = $activeSignature;
-        if ($this->activeParameter !== null) $this->activeParameter = $activeParameter;
+        if ($this->activeSignature !== null) {
+            $this->activeSignature = $activeSignature;
+        }
+        if ($this->activeParameter !== null) {
+            $this->activeParameter = $activeParameter;
+        }
     }
 
     /**

--- a/src/SignatureHelpClientCapabilities.php
+++ b/src/SignatureHelpClientCapabilities.php
@@ -38,15 +38,9 @@ class SignatureHelpClientCapabilities implements JsonSerializable
         SignatureHelpClientCapabilitiesSignatureInformation $signatureInformation = null,
         bool $contextSupport = null
     ) {
-        if ($this->dynamicRegistration !== null) {
-            $this->dynamicRegistration = $dynamicRegistration;
-        }
-        if ($this->signatureInformation !== null) {
-            $this->signatureInformation = $signatureInformation;
-        }
-        if ($this->contextSupport !== null) {
-            $this->contextSupport = $contextSupport;
-        }
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->signatureInformation = $signatureInformation;
+        $this->contextSupport = $contextSupport;
     }
 
     /**
@@ -58,6 +52,8 @@ class SignatureHelpClientCapabilities implements JsonSerializable
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
-        return array_filter(get_object_vars($this));
+        return array_filter(get_object_vars($this), function ($v) {
+            return $v !== null;
+        });
     }
 }

--- a/src/SignatureHelpClientCapabilities.php
+++ b/src/SignatureHelpClientCapabilities.php
@@ -38,9 +38,15 @@ class SignatureHelpClientCapabilities implements JsonSerializable
         SignatureHelpClientCapabilitiesSignatureInformation $signatureInformation = null,
         bool $contextSupport = null
     ) {
-        if ($this->dynamicRegistration !== null) $this->dynamicRegistration = $dynamicRegistration;
-        if ($this->signatureInformation !== null) $this->signatureInformation = $signatureInformation;
-        if ($this->contextSupport !== null) $this->contextSupport = $contextSupport;
+        if ($this->dynamicRegistration !== null) {
+            $this->dynamicRegistration = $dynamicRegistration;
+        }
+        if ($this->signatureInformation !== null) {
+            $this->signatureInformation = $signatureInformation;
+        }
+        if ($this->contextSupport !== null) {
+            $this->contextSupport = $contextSupport;
+        }
     }
 
     /**

--- a/src/SignatureHelpClientCapabilities.php
+++ b/src/SignatureHelpClientCapabilities.php
@@ -2,7 +2,9 @@
 
 namespace LanguageServerProtocol;
 
-class SignatureHelpClientCapabilities
+use JsonSerializable;
+
+class SignatureHelpClientCapabilities implements JsonSerializable
 {
     /**
      * Whether signature help supports dynamic registration.
@@ -36,8 +38,20 @@ class SignatureHelpClientCapabilities
         SignatureHelpClientCapabilitiesSignatureInformation $signatureInformation = null,
         bool $contextSupport = null
     ) {
-        $this->dynamicRegistration = $dynamicRegistration;
-        $this->signatureInformation = $signatureInformation;
-        $this->contextSupport = $contextSupport;
+        if ($this->dynamicRegistration !== null) $this->dynamicRegistration = $dynamicRegistration;
+        if ($this->signatureInformation !== null) $this->signatureInformation = $signatureInformation;
+        if ($this->contextSupport !== null) $this->contextSupport = $contextSupport;
+    }
+
+    /**
+     * This is needed because VSCode Does not like nulls
+     * meaning if a null is sent then this will not compute
+     *
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        return array_filter(get_object_vars($this));
     }
 }

--- a/src/SignatureHelpOptions.php
+++ b/src/SignatureHelpOptions.php
@@ -2,10 +2,12 @@
 
 namespace LanguageServerProtocol;
 
+use JsonSerializable;
+
 /**
  * Signature help options.
  */
-class SignatureHelpOptions
+class SignatureHelpOptions implements JsonSerializable
 {
     /**
      * The characters that trigger signature help automatically.
@@ -19,6 +21,18 @@ class SignatureHelpOptions
      */
     public function __construct(array $triggerCharacters = null)
     {
-        $this->triggerCharacters = $triggerCharacters;
+        if ($this->triggerCharacters !== null) $this->triggerCharacters = $triggerCharacters;
+    }
+
+    /**
+     * This is needed because VSCode Does not like nulls
+     * meaning if a null is sent then this will not compute
+     *
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        return array_filter(get_object_vars($this));
     }
 }

--- a/src/SignatureHelpOptions.php
+++ b/src/SignatureHelpOptions.php
@@ -21,9 +21,7 @@ class SignatureHelpOptions implements JsonSerializable
      */
     public function __construct(array $triggerCharacters = null)
     {
-        if ($this->triggerCharacters !== null) {
-            $this->triggerCharacters = $triggerCharacters;
-        }
+        $this->triggerCharacters = $triggerCharacters;
     }
 
     /**

--- a/src/SignatureHelpOptions.php
+++ b/src/SignatureHelpOptions.php
@@ -21,7 +21,9 @@ class SignatureHelpOptions implements JsonSerializable
      */
     public function __construct(array $triggerCharacters = null)
     {
-        if ($this->triggerCharacters !== null) $this->triggerCharacters = $triggerCharacters;
+        if ($this->triggerCharacters !== null) {
+            $this->triggerCharacters = $triggerCharacters;
+        }
     }
 
     /**

--- a/src/SignatureInformation.php
+++ b/src/SignatureInformation.php
@@ -2,12 +2,14 @@
 
 namespace LanguageServerProtocol;
 
+use JsonSerializable;
+
 /**
  * Represents the signature of something callable. A signature
  * can have a label, like a function-name, a doc-comment, and
  * a set of parameters.
  */
-class SignatureInformation
+class SignatureInformation implements JsonSerializable
 {
     /**
      * The label of this signature. Will be shown in
@@ -59,8 +61,20 @@ class SignatureInformation
         int $activeParameter = null
     ) {
         $this->label = $label;
-        $this->parameters = $parameters;
-        $this->documentation = $documentation;
-        $this->activeParameter = $activeParameter;
+        if ($this->parameters !== null) $this->parameters = $parameters;
+        if ($this->documentation !== null) $this->documentation = $documentation;
+        if ($this->activeParameter !== null) $this->activeParameter = $activeParameter;
+    }
+
+    /**
+     * This is needed because VSCode Does not like nulls
+     * meaning if a null is sent then this will not compute
+     *
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        return array_filter(get_object_vars($this));
     }
 }

--- a/src/SignatureInformation.php
+++ b/src/SignatureInformation.php
@@ -61,9 +61,15 @@ class SignatureInformation implements JsonSerializable
         int $activeParameter = null
     ) {
         $this->label = $label;
-        if ($this->parameters !== null) $this->parameters = $parameters;
-        if ($this->documentation !== null) $this->documentation = $documentation;
-        if ($this->activeParameter !== null) $this->activeParameter = $activeParameter;
+        if ($this->parameters !== null) {
+            $this->parameters = $parameters;
+        }
+        if ($this->documentation !== null) {
+            $this->documentation = $documentation;
+        }
+        if ($this->activeParameter !== null) {
+            $this->activeParameter = $activeParameter;
+        }
     }
 
     /**

--- a/src/SignatureInformation.php
+++ b/src/SignatureInformation.php
@@ -61,15 +61,9 @@ class SignatureInformation implements JsonSerializable
         int $activeParameter = null
     ) {
         $this->label = $label;
-        if ($this->parameters !== null) {
-            $this->parameters = $parameters;
-        }
-        if ($this->documentation !== null) {
-            $this->documentation = $documentation;
-        }
-        if ($this->activeParameter !== null) {
-            $this->activeParameter = $activeParameter;
-        }
+        $this->parameters = $parameters;
+        $this->documentation = $documentation;
+        $this->activeParameter = $activeParameter;
     }
 
     /**
@@ -81,6 +75,8 @@ class SignatureInformation implements JsonSerializable
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
-        return array_filter(get_object_vars($this));
+        return array_filter(get_object_vars($this), function ($v) {
+            return $v !== null;
+        });
     }
 }


### PR DESCRIPTION
According to LSP https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_signatureHelp SignatureInformation is not allowed to send `null` for fields like [SignatureInformation](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#signatureInformation) `documentation`. 